### PR TITLE
Chat postMessage argument error only if both attachments and text are missing

### DIFF
--- a/lib/slack/web/api/endpoints/chat.rb
+++ b/lib/slack/web/api/endpoints/chat.rb
@@ -49,7 +49,7 @@ module Slack
           # @see https://github.com/slackhq/slack-api-docs/blob/master/methods/chat.postMessage.json
           def chat_postMessage(options = {})
             throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :text missing') if options[:text].nil?
+            throw ArgumentError.new('Required arguments :text and :attachments missing') if options[:text].nil? && options[:attachments].nil?
             post('chat.postMessage', options)
           end
 


### PR DESCRIPTION
The slack chat http api allows you to send no text field if you do provide attachments. This change will stop the local validation from blocking that use case.