### PR TITLE
Client stop method fails as the connected? method is a protected in Slack::RealTime::Concurrency::Celluloid::Socket class

### DIFF
--- a/lib/slack/real_time/concurrency/celluloid.rb
+++ b/lib/slack/real_time/concurrency/celluloid.rb
@@ -32,6 +32,10 @@ module Slack
             future.run_loop
           end
 
+          def connected?
+            !@connected.nil?
+          end
+
           def run_loop
             loop { read } if socket
           rescue EOFError
@@ -61,10 +65,6 @@ module Slack
             def join
               @future.value
             end
-          end
-
-          def connected?
-            !@connected.nil?
           end
 
           def build_socket


### PR DESCRIPTION
Made the `connected?` method public in [Slack::RealTime::Concurrency::Celluloid::Socket](https://github.com/workato/slack-ruby-client/blob/5b83b24cb6591c09b26c09bb29ce47dd9d637702/lib/slack/real_time/concurrency/celluloid.rb#L35)