### PR TITLE
[celluloid] fix call on protected method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.5.4 (Next)
 
 * Your contribution here.
+* [#49](https://github.com/dblock/slack-ruby-client/pull/49): Fix: Celluloid `#connected?` method. - [@mikz](https://github.com/mikz), [@kandadaboggu](https://github.com/kandadaboggu).
 
 ### 0.5.3 (1/11/2016)
 

--- a/lib/slack/real_time/concurrency/celluloid.rb
+++ b/lib/slack/real_time/concurrency/celluloid.rb
@@ -50,6 +50,10 @@ module Slack
             Actor.new(future)
           end
 
+          def connected?
+            !@connected.nil?
+          end
+
           protected
 
           class Actor
@@ -62,10 +66,6 @@ module Slack
             def join
               @future.value
             end
-          end
-
-          def connected?
-            !@connected.nil?
           end
 
           def build_socket

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -69,6 +69,8 @@ RSpec.describe 'integration test', skip: !ENV['SLACK_API_TOKEN'] && 'missing SLA
       start_server
     end
 
+    let(:channel) { "@#{client.self['name']}" }
+
     it 'responds to message' do
       message = SecureRandom.hex
 
@@ -81,8 +83,13 @@ RSpec.describe 'integration test', skip: !ENV['SLACK_API_TOKEN'] && 'missing SLA
         client.stop!
       end
 
-      logger.debug "chat_postMessage, channel=@#{client.self['name']}, message=#{message}"
-      client.web_client.chat_postMessage channel: "@#{client.self['name']}", text: message
+      logger.debug "chat_postMessage, channel=#{channel}, message=#{message}"
+      client.web_client.chat_postMessage channel: channel, text: message
+    end
+
+    it 'sends message' do
+      client.message(channel: channel, text: 'Hello world!')
+      client.stop!
     end
   end
 


### PR DESCRIPTION
closes #40

```
E, [2016-01-18T18:58:44.358004 #48656] ERROR -- : Actor crashed!
NoMethodError: protected method `connected?' called for #<Slack::RealTime::Concurrency::Celluloid::Socket:0x007f8d73c5f3c0>
	/Users/user/.rvm/gems/ruby-2.2.4/gems/celluloid-0.17.2/lib/celluloid/calls.rb:28:in `public_send'
	/Users/user/.rvm/gems/ruby-2.2.4/gems/celluloid-0.17.2/lib/celluloid/calls.rb:28:in `dispatch'
	/Users/user/.rvm/gems/ruby-2.2.4/gems/celluloid-0.17.2/lib/celluloid/call/sync.rb:16:in `dispatch'
	/Users/user/.rvm/gems/ruby-2.2.4/gems/celluloid-0.17.2/lib/celluloid/cell.rb:50:in `block in dispatch'
	/Users/user/.rvm/gems/ruby-2.2.4/gems/celluloid-0.17.2/lib/celluloid/cell.rb:76:in `block in task'
	/Users/user/.rvm/gems/ruby-2.2.4/gems/celluloid-0.17.2/lib/celluloid/actor.rb:339:in `block in task'
	/Users/user/.rvm/gems/ruby-2.2.4/gems/celluloid-0.17.2/lib/celluloid/task.rb:44:in `block in initialize'
	/Users/user/.rvm/gems/ruby-2.2.4/gems/celluloid-0.17.2/lib/celluloid/task/fibered.rb:14:in `block in create'
[2016-01-18 18:58:44] ERROR NoMethodError: protected method `connected?' called for #<Slack::RealTime::Concurrency::Celluloid::Socket:0x007f8d73c5f3c0>
	/Users/user/.rvm/gems/ruby-2.2.4/gems/celluloid-0.17.2/lib/celluloid/calls.rb:28:in `public_send'
	/Users/user/.rvm/gems/ruby-2.2.4/gems/celluloid-0.17.2/lib/celluloid/calls.rb:28:in `dispatch'
	/Users/user/.rvm/gems/ruby-2.2.4/gems/celluloid-0.17.2/lib/celluloid/call/sync.rb:16:in `dispatch'
	/Users/user/.rvm/gems/ruby-2.2.4/gems/celluloid-0.17.2/lib/celluloid/cell.rb:50:in `block in dispatch'
	/Users/user/.rvm/gems/ruby-2.2.4/gems/celluloid-0.17.2/lib/celluloid/cell.rb:76:in `block in task'
	/Users/user/.rvm/gems/ruby-2.2.4/gems/celluloid-0.17.2/lib/celluloid/actor.rb:339:in `block in task'
	/Users/user/.rvm/gems/ruby-2.2.4/gems/celluloid-0.17.2/lib/celluloid/task.rb:44:in `block in initialize'
	/Users/user/.rvm/gems/ruby-2.2.4/gems/celluloid-0.17.2/lib/celluloid/task/fibered.rb:14:in `block in create'
	(celluloid):0:in `remote procedure call'
	/Users/user/.rvm/gems/ruby-2.2.4/gems/celluloid-0.17.2/lib/celluloid/call/sync.rb:45:in `value'
	/Users/user/.rvm/gems/ruby-2.2.4/gems/celluloid-0.17.2/lib/celluloid/proxy/sync.rb:38:in `method_missing'
	/Users/user/.rvm/gems/ruby-2.2.4/gems/slack-ruby-client-0.5.3/lib/slack/real_time/client.rb:56:in `started?'
	/Users/user/.rvm/gems/ruby-2.2.4/gems/slack-ruby-client-0.5.3/lib/slack/real_time/client.rb:114:in `send_json'
	/Users/user/.rvm/gems/ruby-2.2.4/gems/slack-ruby-client-0.5.3/lib/slack/real_time/api/message.rb:15:in `message'
```

so move the `#connected?` to public

## TODO

- [ ] add a test
