### PR TITLE
Add Ruby 2.3.0 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 cache: bundler
 
 rvm:
+  - 2.3.0
   - 2.2
   - 2.1
   - 2.0


### PR DESCRIPTION
- Tests pass under ruby 2.3: https://travis-ci.org/harlantwood/slack-ruby-client/builds/112131523
- For whatever reason the string "2.3" doesn't work, but "2.3.0" does (rvm issue perhaps)

See also #42