### PR TITLE
add a 'closed' event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.7.1 (Next)
 
 * Your contribution here.
+* [#73](https://github.com/dblock/slack-ruby-client/issues/73): Add a `closed` event - [@rkadyb](https://github.com/rkadyb).
 * [#69](https://github.com/dblock/slack-ruby-client/issues/69): Add attachments support for `Slack::Web::Api::Endpoints::Chat.chat_update` - [@nicka](https://github.com/nicka).
 
 ### 0.7.0 (3/6/2016)

--- a/README.md
+++ b/README.md
@@ -194,6 +194,14 @@ client.on :message do |data|
   end
 end
 
+client.on :close do |_data|
+  puts "Client is about to disconnect"
+end
+
+client.on :closed do |_data|
+  puts "Client has disconnected successfully!"
+end
+
 client.start!
 ```
 

--- a/examples/hi_real_time/hi.rb
+++ b/examples/hi_real_time/hi.rb
@@ -27,8 +27,12 @@ client.on :message do |data|
 end
 
 client.on :close do |_data|
-  puts 'Connection closed, exiting.'
+  puts 'Connection closing, exiting.'
   EM.stop
+end
+
+client.on :closed do |_data|
+  puts 'Connection has been disconnected.'
 end
 
 client.start!

--- a/lib/slack/real_time/client.rb
+++ b/lib/slack/real_time/client.rb
@@ -119,6 +119,7 @@ module Slack
             logger.debug("#{self.class}##{__method__}") { event.class.name }
             callback(event, :close)
             close(event)
+            callback(event, :closed)
           end
         end
       end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -116,4 +116,24 @@ RSpec.describe 'integration test', skip: !ENV['SLACK_API_TOKEN'] && 'missing SLA
 
     start_server
   end
+
+  it 'gets close, followed by closed' do
+    client.on :hello do
+      expect(client.started?).to be true
+      client.stop!
+    end
+
+    client.on :close do |data|
+      logger.debug "client.on :close, data=#{data}"
+      expect(client.started?).to be true
+      @close_called = true
+    end
+
+    client.on :closed do |data|
+      logger.debug "client.on :closed, data=#{data}"
+      expect(@close_called).to be true
+    end
+
+    start_server
+  end
 end


### PR DESCRIPTION
I ended up needing an 'after-close' event for a project I'm working on, figured I'd share this in case it's worthwhile for anyone else.

### Reasoning:
The existing `:close`event is fired BEFORE the websocket connection is actually closed, which makes sense if you want to send a message / use the API immediately before disconnect. This isn't as helpful if you want to do something not related to the API AFTER the disconnect.