### PR TITLE
update API with `chat.meMessage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.7.5 (Next)
 
 * Your contribution here.
+* [#97](https://github.com/dblock/slack-ruby-client/issues/97): Add chat.meMessage - [@aaronpk](https://github.com/aaronpk)
 
 ### 0.7.4 (5/28/2016)
 

--- a/bin/commands/chat.rb
+++ b/bin/commands/chat.rb
@@ -13,6 +13,16 @@ command 'chat' do |g|
     end
   end
 
+  g.desc 'This method sends a me message to a channel from the calling user.'
+  g.long_desc %( This method sends a me message to a channel from the calling user. )
+  g.command 'meMessage' do |c|
+    c.flag 'channel', desc: 'Channel, private group, or IM channel to send message to. Can be an encoded ID, or a name.'
+    c.flag 'text', desc: 'Text of the message to send.'
+    c.action do |_global_options, options, _args|
+      puts JSON.dump($client.chat_meMessage(options))
+    end
+  end
+
   g.desc 'This method posts a message to a public channel, private channel, or direct message/IM channel.'
   g.long_desc %( This method posts a message to a public channel, private channel, or direct message/IM channel. )
   g.command 'postMessage' do |c|

--- a/lib/slack/web/api/endpoints/chat.rb
+++ b/lib/slack/web/api/endpoints/chat.rb
@@ -24,6 +24,21 @@ module Slack
           end
 
           #
+          # This method sends a me message to a channel from the calling user.
+          #
+          # @option options [channel] :channel
+          #   Channel, private group, or IM channel to send message to. Can be an encoded ID, or a name.
+          # @option options [Object] :text
+          #   Text of the message to send.
+          # @see https://api.slack.com/methods/chat.meMessage
+          # @see https://github.com/dblock/slack-api-ref/blob/master/methods/chat/chat.meMessage.json
+          def chat_meMessage(options = {})
+            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+            throw ArgumentError.new('Required arguments :text missing') if options[:text].nil?
+            post('chat.meMessage', options)
+          end
+
+          #
           # This method posts a message to a public channel, private channel, or direct message/IM channel.
           #
           # @option options [channel] :channel


### PR DESCRIPTION
This was generated from slack-api-ref with the new method included.

closes #97 